### PR TITLE
[READY] - Adding nix-garage overlay to driver

### DIFF
--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -90,6 +90,7 @@ in
     systemPackages = with pkgs; [
       wget
       git
+      gh
       tmux
       ag
       stow

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -26,10 +26,11 @@ let
   myvim = pkgs.vim_configurable.override { python = pkgs.python3; };
 in
 {
-  #imports =
-  #  [ # Include the results of the hardware scan.
-  #    /etc/nixos/hardware-configuration.nix
-  #  ];
+  imports =
+    [
+      # Import nix-garage
+      ./nix-garage-overlay.nix
+    ];
 
   # Necessary in most configurations
   nixpkgs.config.allowUnfree = true;

--- a/nix/machines/driver/nix-garage-overlay.nix
+++ b/nix/machines/driver/nix-garage-overlay.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, ... }:
+
+let
+  # Using pkgs.fetchFromGitHub causes infinite recursion
+  nix-garage = builtins.fetchGit {
+    url = "https://github.com/nebulaworks/nix-garage";
+    ref = "e5baed156d59f36776ef8e4e8cd63d8850ed63fa";
+  };
+  garage-overlay = import (nix-garage.outPath + "/overlay.nix");
+in
+{
+  nixpkgs.overlays = [ garage-overlay ];
+
+  # install Nebulaworks packages
+  environment.systemPackages = with pkgs; [
+    aws-key-rotator
+    git-divergence
+    sshcb
+    terraform-config-inspect
+  ];
+}


### PR DESCRIPTION
## Description

Finally getting to consume the nix-garage overlay properly: https://github.com/Nebulaworks/nix-garage

## AC
- nix-rebuild switch
- Confirmation of overlay packages installed on my system:

```
$ aws-key-rotator -h                                                                                                                                                                           
usage: aws-key-rotator [-h] [-c CREDENTIALS] [-v] [--include INCLUDE | --exclude EXCLUDE]                                                                                                                           
                                                                                                          
optional arguments:                                                                                       
  -h, --help            show this help message and exit                                                   
  -c CREDENTIALS, --credentials CREDENTIALS          
                        Path to AWS credentials file                                                      
  -v, --verbose         Verbose output               
  --include INCLUDE     Comma separated list of profile names, will only rotate specified profiles' keys  
  --exclude EXCLUDE     Comma separated list of profile names, will rotate all profiles excluding         
                        specified
$ sshcb -h
Connect to your environment quickly and easily
               by querying a cloud api and building an ssh_config

Usage:
  sshcb [flags]
  sshcb [command]

Available Commands:
  help        Help about any command
  version     Print the version number of SSHcb

Flags:
  -b, --bastionhost string    bastion IP or hostname into AWS
  -h, --help                  help for sshcb
  -i, --identityfile string   IdentifyFile for ssh
  -o, --output string         Output Location of SSH Config (default "./config")
      --private               Default to using all private IPs to build config
  -p, --profile string        AWS profile to use from ~/.aws/credentials
  -r, --region string         Datacenter region
      --tags strings          instance tags AWS in the form of key:value
  -u, --username string       SSH Username (default "ec2-user")
  -v, --verbose               esoteric output

Use "sshcb [command] --help" for more information about a command.
```