### PR TITLE
[READY] - More packages, systemd tmp linker, and 21.05 upgrade changes

### DIFF
--- a/nix/lib/generic-linker.nix
+++ b/nix/lib/generic-linker.nix
@@ -1,0 +1,9 @@
+# Isaacs Generic Linker
+# A great way of managing your home directory and other files on the system
+files: BaseDir:
+let
+  link = origin: target: "L+ ${target} - - - - ${origin}";
+in
+{
+  systemd.tmpfiles.rules = map ({ origin, target }: link origin "${BaseDir}/${target}") files;
+}

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -19,6 +19,7 @@ in
     myVim # Custom vim
     nixpkgs-fmt
     shellcheck
+    tree
     manix # useful search for nix docs
     unzip
   ];

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -3,7 +3,7 @@
 
 let
   # Need the pythons in my vims
-  myVim = pkgs.vim_configurable.override { python = pkgs.python3; };
+  myVim = pkgs.vim_configurable.override { pythonSupport = true; };
 in
 {
   # install Nebulaworks packages
@@ -12,7 +12,7 @@ in
     git
     git-lfs
     tmux
-    ag
+    silver-searcher
     stow
     gnumake
     lsof

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -9,13 +9,13 @@ let
     nixExtensions = [
       (pkgs.fetchFirefoxAddon {
         name = "ublock"; # Has to be unique!
-        url = "https://addons.mozilla.org/firefox/downloads/file/3933192/ublock_origin-1.42.4-an+fx.xpi"; # Get this from about:addons
-        sha256 = "sha256:1kirlfp5x10rdkgzpj6drbpllryqs241fm8ivm0cns8jjrf36g5w";
+        url = "https://addons.mozilla.org/firefox/downloads/file/3998742/ublock_origin-1.44.2.xpi"; # Get this from about:addons
+        sha256 = "sha256:0zvsjsjlp0r1glqf0qpv425zshrwmimk1in1v339acwy1ysxkx00";
       })
       (pkgs.fetchFirefoxAddon {
         name = "bitwarden";
-        url = "https://addons.mozilla.org/firefox/downloads/file/3940986/bitwarden_free_password_manager-1.58.0-an+fx.xpi";
-        sha256 = "sha256:062v695pmy1nvhav13750dqav69mw6i9yfdfspkxz9lv4j21fram";
+        url = "https://addons.mozilla.org/firefox/downloads/file/3986147/bitwarden_password_manager-2022.8.0.xpi";
+        sha256 = "sha256:002lap6vn1n1k7w1pmrm996dg4x9802yvq33csyyizc6iwsbm3r0";
       })
       (pkgs.fetchFirefoxAddon {
         name = "zoomScheduler";

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -30,6 +30,7 @@ in
   # install Desktop packages
   environment.systemPackages = with pkgs; [
     myFirefox # robs custom firefox
+    chromium
     scrot # screenshots
     feh # set wallpaper
     zoom-us

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -19,6 +19,11 @@ in
   # Necessary in most configurations
   nixpkgs.config.allowUnfree = true;
 
+  # remove the annoying experimental warnings
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
+
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -13,6 +13,7 @@ in
       ../_common/base.nix
       # Import nix-garage
       ./nix-garage-overlay.nix
+      ./home.nix
     ];
 
   # Necessary in most configurations

--- a/nix/machines/driver/dotfiles.nix
+++ b/nix/machines/driver/dotfiles.nix
@@ -1,0 +1,27 @@
+{ lib, stdenvNoCC, fetchgit }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "sarcasticadmin-dotfiles-unstable";
+  version = "09-07-2022";
+
+  src = fetchgit {
+    url = "https://github.com/sarcasticadmin/dotfiles";
+    rev = "6a8f06f8272f768b8ec089512138f87f94b9e393";
+    sha256 = "sha256:1q1ky7bdq5zjd6fdbnff36i8nqwf28h8fds2hcn0wan66rplmiks";
+  };
+
+  phases = "unpackPhase patchPhase installPhase";
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R . $out/
+  '';
+
+  meta = with lib; {
+    description = "My dotfiles and configs for sanity";
+    homepage = "https://github.com/sarcasticadmin/dotfiles";
+    license = licenses.mit;
+    maintainers =  with maintainers; [ sarcasticadmin ];
+    platforms = platforms.unix;
+  };
+}

--- a/nix/machines/driver/home.nix
+++ b/nix/machines/driver/home.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+let
+  # Locals
+  dotfiles = pkgs.callPackage ./dotfiles.nix { };
+  linker = import ../../lib/generic-linker.nix;
+in
+  # Small example use case
+  linker [{
+  origin = "${dotfiles}/xpdf/.xpdfrc";
+  target = ".xpdfrc";
+}] "/home/rherna"

--- a/nix/machines/driver/nix-garage-overlay.nix
+++ b/nix/machines/driver/nix-garage-overlay.nix
@@ -4,7 +4,7 @@ let
   # Using pkgs.fetchFromGitHub causes infinite recursion
   nix-garage = builtins.fetchGit {
     url = "https://github.com/nebulaworks/nix-garage";
-    ref = "e5baed156d59f36776ef8e4e8cd63d8850ed63fa";
+    rev = "e5baed156d59f36776ef8e4e8cd63d8850ed63fa";
   };
   garage-overlay = import (nix-garage.outPath + "/overlay.nix");
 in


### PR DESCRIPTION
## Description

1. Upgraded workstation to 21.05 - Needed to chance a few refs of packages and things to get the rebuild switch to work
2. Adding second browser so that I can have more options if firefox doesnt work for some web apps
3. Dotfiles and symlinking to home dir are now possibly without having to leverage home-manager

## Testing

- Workstation rebuilt and reboots fine