### PR TITLE
[READY] - power management, zfs snapshotting, and pkgs

### DIFF
--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -8,6 +8,7 @@ in
 {
   # install Nebulaworks packages
   environment.systemPackages = with pkgs; [
+    dig
     wget
     git
     git-lfs
@@ -15,6 +16,7 @@ in
     silver-searcher
     stow
     gnumake
+    jq
     lsof
     myVim # Custom vim
     nixpkgs-fmt

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -132,8 +132,17 @@ in
   # networking.firewall.enable = false;
 
   # ZFS
-  services.zfs.autoScrub.enable = true;
-  services.zfs.autoScrub.interval = "weekly";
+  services.zfs = {
+    autoScrub = {
+      enable = true;
+      interval = "weekly";
+    };
+    autoSnapshot = {
+      enable = true;
+      monthly = 3;
+    };
+  };
+
   systemd.services.zfs-scrub.unitConfig.ConditionACPower = true;
 
   # This value determines the NixOS release from which the default

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -145,6 +145,10 @@ in
 
   systemd.services.zfs-scrub.unitConfig.ConditionACPower = true;
 
+  # dont hiberate/sleep by default
+  powerManagement.enable = false;
+  # Enable tlp for stricter governance of power management
+  services.tlp.enable = true;
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave


### PR DESCRIPTION
## Description

- Attempting to do better on power management via `tlp`.
- Disabling the default power management config since I dont want the machine to hibernate/sleep automatically
- zfs snapshotting enabled with defaults and max of 3 months snapshots
- missing `dig` and `jq` from base modules