### PR TITLE
[READY] - tty pinentry, generations cron, bump nix-garage

### DIFF
--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -124,7 +124,7 @@ in
   # programs.mtr.enable = true;
   programs.gnupg.agent = {
     enable = true;
-    pinentryFlavor = "curses";
+    pinentryFlavor = "tty";
     # Make pinentry across multiple terminal windows, seamlessly
     enableSSHSupport = true;
   };

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -115,6 +115,16 @@ in
     ];
   };
 
+  services.cron = {
+    enable = true;
+    # Clean up nixOS generations
+    # NOTE: Still requires a nix-rebuild switch to update grub
+    # List generations: nix-env --list-generations -p /nix/var/nix/profiles/system
+    systemCronJobs = [
+      "0 1 * * * root nix-env --delete-generations +10 -p /nix/var/nix/profiles/system 2>&1 | logger -t generations-cleanup"
+    ];
+  };
+
   services.logind.extraConfig = "HandleLidSwitch=ignore";
 
   # part of gnupg reqs

--- a/nix/machines/driver/nix-garage-overlay.nix
+++ b/nix/machines/driver/nix-garage-overlay.nix
@@ -4,7 +4,7 @@ let
   # Using pkgs.fetchFromGitHub causes infinite recursion
   nix-garage = builtins.fetchGit {
     url = "https://github.com/nebulaworks/nix-garage";
-    rev = "e5baed156d59f36776ef8e4e8cd63d8850ed63fa";
+    rev = "22a0c8fb0b39bf3a440fdf3e2ff514a24022a13d";
   };
   garage-overlay = import (nix-garage.outPath + "/overlay.nix");
 in


### PR DESCRIPTION
## Description

- gpg pinentry set to tty instead of curses (curses takes up the entire screen and tty is my preference)
- generations cron to keep only last 10 generations
- bumping nix-garage to removing ldbuildflags warning from previous versions