### PR TITLE
[READY] - nixos 22.11 update, glab, and docker

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671525405,
-        "narHash": "sha256-MEgNxm/oRt5w4ycMENewfZQKOak0ixmjVPfXM96N1FA=",
+        "lastModified": 1674781052,
+        "narHash": "sha256-nseKFXRvmZ+BDAeWQtsiad+5MnvI/M2Ak9iAWzooWBw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbe419ed4c8f98bd82d169c321d339ea30904f1f",
+        "rev": "cc4bb87f5457ba06af9ae57ee4328a49ce674b1b",
         "type": "github"
       },
       "original": {

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -83,6 +83,7 @@ in
     systemPackages = with pkgs; [
       awscli2
       gh
+      glab
       ticker # stocks
       newsboat
       imagemagick

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -73,7 +73,7 @@ in
   users.users.rherna = {
     isNormalUser = true;
     uid = 1000;
-    extraGroups = [ "wheel" "audio" "sound" ]; # Enable ‘sudo’ for the user.
+    extraGroups = [ "wheel" "audio" "sound" "docker" ]; # Enable ‘sudo’ for the user.
     openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
   };
 
@@ -168,6 +168,8 @@ in
       monthly = 3;
     };
   };
+
+  virtualisation.docker.enable = true;
 
   systemd.services.zfs-scrub.unitConfig.ConditionACPower = true;
 

--- a/nix/machines/driver/nix-garage-overlay.nix
+++ b/nix/machines/driver/nix-garage-overlay.nix
@@ -15,7 +15,8 @@ in
   environment.systemPackages = with pkgs; [
     aws-key-rotator
     git-divergence
-    sshcb
+    # Currently broken
+    #sshcb
     terraform-config-inspect
   ];
 }


### PR DESCRIPTION
## Description

- init glab pkg in workstation
- updating to latest for nixos 22.11
- remove sshcb from overlay since broken
- enable docker on driver
