### PR TITLE
[READY] - new pkgs and flake input bump for 22.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674781052,
-        "narHash": "sha256-nseKFXRvmZ+BDAeWQtsiad+5MnvI/M2Ak9iAWzooWBw=",
+        "lastModified": 1680588688,
+        "narHash": "sha256-SW95w50Pdw3nivgTuCebtbbPqaCTp9ctnFMNj24vdck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cc4bb87f5457ba06af9ae57ee4328a49ce674b1b",
+        "rev": "3e01f83884b8ed7cbafa784727fb343f1876d56f",
         "type": "github"
       },
       "original": {

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -23,6 +23,7 @@ in
     lsof
     myVim # Custom vim
     nixpkgs-fmt
+    openssl
     shellcheck
     tree
     manix # useful search for nix docs

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -14,6 +14,7 @@ in
     wget
     git
     git-lfs
+    ldns
     tmux
     silver-searcher
     stow

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -94,6 +94,7 @@ in
       gnupg
       pcsclite
       pinentry
+      tailscale
     ];
 
     etc."wpa_supplicant.conf" = {
@@ -126,6 +127,13 @@ in
       "0 1 * * * root nix-env --delete-generations +10 -p /nix/var/nix/profiles/system 2>&1 | logger -t generations-cleanup"
     ];
   };
+
+  # Dont start tailscale by default
+  services.tailscale.enable = false;
+  # didnt work for me
+  #systemd.services.tailscaled.after = [ "network-online.target" "systemd-resolved.service" ];
+  # Remove warning from tailscale: Strict reverse path filtering breaks Tailscale exit node use and some subnet routing setups
+  networking.firewall.checkReversePath = "loose";
 
   services.logind.extraConfig = "HandleLidSwitch=ignore";
 

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -127,6 +127,7 @@ in
       "0 1 * * * root nix-env --delete-generations +10 -p /nix/var/nix/profiles/system 2>&1 | logger -t generations-cleanup"
     ];
   };
+  services.fwupd.enable = true;
 
   # Dont start tailscale by default
   services.tailscale.enable = false;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -86,6 +86,7 @@ in
       glab
       ticker # stocks
       newsboat
+      icdiff
       imagemagick
       magic-wormhole
       nixpkgs-review


### PR DESCRIPTION
## Description

- init drill pkg in base
- init icdiff pkg in driver
- init openssl in base
- init tailscale on driver
- init fwupd on driver
- bump flake.lock for 22.11

Additionally, needed to get the latest backport version of `nixpkgs-review` since it looks like github's API changed
