### PR TITLE
[READY] - cntr, sleep, and andriod udev

### DIFF
--- a/_bootstrap/robs-nixos.sh
+++ b/_bootstrap/robs-nixos.sh
@@ -122,6 +122,14 @@ zfs create -p -o mountpoint=legacy "$ZFS_DS_NIX"
 info "Disabling access time setting for '$ZFS_DS_NIX' ZFS dataset ..."
 zfs set atime=off "$ZFS_DS_NIX"
 
+# Required for cntr to work
+# Ref: https://github.com/Mic92/cntr/issues/108
+# The key advantage of this type of xattr is improved performance.
+# Storing xattrs as system attributes significantly decreases the amount of disk IO required
+info "Enable posixacl and xttr=sa on ZFS dataset ..."
+zfs set xattr=sa "$ZFS_DS_NIX"
+zfs set acltype=posixacl "$ZFS_DS_NIX"
+
 info "Mounting '$ZFS_DS_NIX' to /mnt/nix ..."
 mkdir /mnt/nix
 mount -t zfs "$ZFS_DS_NIX" /mnt/nix

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -24,6 +24,7 @@ in
     myVim # Custom vim
     nixpkgs-fmt
     openssl
+    parted
     shellcheck
     tree
     manix # useful search for nix docs

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -111,6 +111,7 @@ in
       gnupg
       pcsclite
       pinentry
+      strace
       tailscale
     ];
 

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -4,7 +4,17 @@
 
 { config, pkgs, ... }:
 let
-  # Locals
+  # for pixel USB device rules
+  # TODO: Remove after 23.05 release
+  my-android-udev-rules = pkgs.android-udev-rules.overrideDerivation (oldAttrs: {
+    pname = "android-udev-rules-unstable";
+    src = pkgs.fetchFromGitHub {
+      owner = "M0Rf30";
+      repo = "android-udev-rules";
+      rev = "20230303";
+      sha256 = "sha256-ddalOVt0gLuTcwk322fNNn6WNZx1Ubsa4MgaG0Lmn2k=";
+    };
+  });
 in
 {
   imports =
@@ -77,9 +87,11 @@ in
   users.users.rherna = {
     isNormalUser = true;
     uid = 1000;
-    extraGroups = [ "wheel" "audio" "sound" "docker" ]; # Enable ‘sudo’ for the user.
+    extraGroups = [ "wheel" "audio" "sound" "docker" "plugdev" ]; # Enable ‘sudo’ for the user.
     openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
   };
+
+  users.groups.plugdev = { };
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
@@ -106,6 +118,8 @@ in
       mode = "symlink";
     };
   };
+
+  services.udev.packages = [ my-android-udev-rules ];
   # Enable the OpenSSH daemon.
   services.openssh = {
     enable = true;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -203,6 +203,10 @@ in
 
   # dont hiberate/sleep by default
   powerManagement.enable = false;
+  systemd.targets.sleep.enable = false;
+  systemd.targets.suspend.enable = false;
+  systemd.targets.hibernate.enable = false;
+  systemd.targets.hybrid-sleep.enable = false;
   # Enable tlp for stricter governance of power management
   # Validate status: `sudo tlp-stat -b`
   services.tlp.enable = true;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -27,6 +27,10 @@ in
     experimental-features = nix-command flakes
   '';
 
+  # enabled apropos and "man -K" searching
+  # https://nixos.org/manual/nixos/stable/options.html#opt-documentation.man.generateCaches
+  documentation.man.generateCaches = true;
+
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -98,6 +98,7 @@ in
   environment = {
     systemPackages = with pkgs; [
       awscli2
+      cntr
       gh
       glab
       ticker # stocks


### PR DESCRIPTION
## Description

- init parted in base
- enable doc cached for apropos and man -K
- init andriod udev rules and plugdev group
- temp solution for disabling sleep behavior
- init cntr on driver
- init strace on driver
