### PR TITLE
[READY] - NixOS 23.05 and necessary config updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680588688,
-        "narHash": "sha256-SW95w50Pdw3nivgTuCebtbbPqaCTp9ctnFMNj24vdck=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e01f83884b8ed7cbafa784727fb343f1876d56f",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
 
   outputs = { self, nixpkgs }: {
     nixosConfigurations = {

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -3,7 +3,7 @@
 
 let
   # Need the pythons in my vims
-  myVim = pkgs.vim_configurable.override { pythonSupport = true; };
+  myVim = pkgs.vim-full.override { pythonSupport = true; };
 in
 {
   # install Nebulaworks packages

--- a/nix/machines/driver/README.md
+++ b/nix/machines/driver/README.md
@@ -10,7 +10,64 @@ make CONFIG=./_make/workstation-pkgs.mk world
 
 2. Log out (alt+shift+e) and log back into i3
 
-## Known Issues
+# Notes
+
+## NixOS Upgrades
+
+Common options for `flake` references:
+
+```
+local filesystem: /home/rherna/systems#driver
+remote git repo: github:sarcasticadmin/systems/0c46f1c6009e2515e51baee6cba621fd7093c41b#driver
+```
+
+### Major
+
+1. Check the release notes for the new version: https://nixos.org/blog/announcements.html
+
+2. Bump the `input` version in the flake then:
+
+```
+nix flake update
+```
+
+3. `dry-run` and then build for next boot:
+
+```
+nixos-rebuild dry-run --flake /home/rherna/systems#driver
+nixos-rebuild boot --flake /home/rherna/systems#driver
+```
+> `dry-run` should help catch any issues in the existing configuration
+
+### Minor
+
+1. Bump the `input` version in the flake then:
+
+```
+nix flake update
+```
+
+2. `switch` the system to the configuration:
+
+```
+nixos-rebuild switch --flake /home/rherna/systems#driver
+```
+
+## autorandr
+
+Show all exiting profiles:
+
+```
+autorandr
+```
+
+Saving a new profile:
+
+```
+autorandr --save mobile
+```
+
+# Known Issues
 
 - wpa_supplicant.conf gets copied to /run/wpa_supplicant/wpa_supplicant.conf during service start. Resulting in the inability to actually update /etc/wpa_supplicant.conf
 

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -171,12 +171,14 @@ in
   };
 
   programs.ssh = {
-    # Fix timeout from client side
-    # Ref: https://www.cyberciti.biz/tips/open-ssh-server-connection-drops-out-after-few-or-n-minutes-of-inactivity.html
     extraConfig = ''
       Host *
+        # Fix timeout from client side
+        # Ref: https://www.cyberciti.biz/tips/open-ssh-server-connection-drops-out-after-few-or-n-minutes-of-inactivity.html
         ServerAliveInterval 15
         ServerAliveCountMax 3
+        # Keep ~C control seq enabled post ssh-9.2
+        EnableEscapeCommandline yes
     '';
   };
   # List services that you want to enable:

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -136,6 +136,11 @@ in
         bits = 4096;
       }
     ];
+    settings = {
+      PermitRootLogin = "no";
+      PasswordAuthentication = false;
+      KbdInteractiveAuthentication = false;
+    };
   };
 
   services.cron = {

--- a/nix/machines/driver/nix-garage-overlay.nix
+++ b/nix/machines/driver/nix-garage-overlay.nix
@@ -13,7 +13,7 @@ in
 
   # install Nebulaworks packages
   environment.systemPackages = with pkgs; [
-    aws-key-rotator
+    #aws-key-rotator
     git-divergence
     # Currently broken
     #sshcb

--- a/nix/machines/sign/configuration.nix
+++ b/nix/machines/sign/configuration.nix
@@ -80,6 +80,11 @@ in
         bits = 4096;
       }
     ];
+    settings = {
+      PermitRootLogin = "no";
+      PasswordAuthentication = false;
+      KbdInteractiveAuthentication = false;
+    };
   };
 
   # ZFS


### PR DESCRIPTION
## Description

- update flake to 23.05
- keep ~C control seq enabled for ssh client
- hardening ssh daemon
- myVim updates for nixos 23.05
- disable aws-key-rotate from nix-garage
- adding notes for upgrades and autorandr
