### PR TITLE
[READY] - AX.25 nixos modules on mulligan

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685950216,
-        "narHash": "sha256-8R/7goS4G5RTdje/ae+9TdmqJLQcF2f9s1SCFYQLAbw=",
+        "lastModified": 1688423485,
+        "narHash": "sha256-RN+3LCe2l8GiRapOsa/Yc6YSqQfv0zeFTXg9Mm8ylhw=",
         "owner": "sarcasticadmin",
         "repo": "ham-overlay",
-        "rev": "97d8f4cd413a334c0d1bba9390b500779e01d31b",
+        "rev": "b6c9db8226ebcb68ce1f88b6731acf0592d27be3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1688423485,
-        "narHash": "sha256-RN+3LCe2l8GiRapOsa/Yc6YSqQfv0zeFTXg9Mm8ylhw=",
+        "lastModified": 1690222048,
+        "narHash": "sha256-iqMPXoe61HzCQeTU59pNthbLSQbrQH2QZvnUE8o0+fE=",
         "owner": "sarcasticadmin",
         "repo": "ham-overlay",
-        "rev": "b6c9db8226ebcb68ce1f88b6731acf0592d27be3",
+        "rev": "c473b3524e3bfab9d53392c9a80075d16c9ed2bd",
         "type": "github"
       },
       "original": {
         "owner": "sarcasticadmin",
         "repo": "ham-overlay",
+        "rev": "c473b3524e3bfab9d53392c9a80075d16c9ed2bd",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     ham-overlay = {
-      url = "github:sarcasticadmin/ham-overlay";
+      url = "github:sarcasticadmin/ham-overlay/c473b3524e3bfab9d53392c9a80075d16c9ed2bd";
       # Make sure to set to the specific input of the remote flake
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,10 @@
           system = "x86_64-linux";
           modules = [
             ({ config, pkgs, ... }: { nixpkgs.overlays = [ ham-overlay.overlays.default ]; })
+            ham-overlay.nixosModules.default.ax25d
+            ham-overlay.nixosModules.default.mheardd
+            ham-overlay.nixosModules.default.axlistend
+            ham-overlay.nixosModules.default.beacond
             ./nix/machines/_common/base.nix
             ./nix/machines/mulligan/configuration.nix
           ];

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -42,6 +42,7 @@
   environment = {
     # Installs all necessary packages for the minimal
     systemPackages = with pkgs; [
+      alsa-utils # Soundcard utils
       ardopc
       aprx
       ax25-tools

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -42,6 +42,7 @@
   environment = {
     # Installs all necessary packages for the minimal
     systemPackages = with pkgs; [
+      ardopc
       aprx
       ax25-tools
       ax25-apps

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -101,6 +101,28 @@ in
     enable = true;
   };
 
+  services.ax25d = {
+    enable = true;
+    package = myAXTools;
+  };
+
+  services.mheardd = {
+    enable = true;
+    package = myAXTools;
+  };
+
+  #services.beacond = {
+  #  enable = true;
+  #  package = myAXTools;
+  #  interval = 5;
+  #  message = "hello this is rob";
+  #};
+
+  services.axlistend = {
+    enable = true;
+    package = myAXTools;
+  };
+
   # Bug in kernels ~5.4<5.19
   # Resulting in pat to error with: address already in use error after first connection
   #boot.kernelPackages = pkgs.linuxPackages_6_0;

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -1,5 +1,14 @@
 { config, pkgs, lib, ... }:
 
+let
+  UdevRulesNinoTNC = pkgs.writeTextFile {
+    name = "extra-udev-rules";
+    text = ''
+      KERNEL=="ttyACM*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="00dd", SYMLINK+="ninotnc" TAG+="systemd" ENV{SYSTEMD_WANTS}+="ax25.target"
+    '';
+    destination = "/etc/udev/rules.d/99-ham.rules";
+  };
+in
 {
   imports =
     [
@@ -72,6 +81,15 @@
     };
 
   };
+
+  services.udev.packages = [ UdevRulesNinoTNC ];
+
+  #boot.initrd.extraUdevRulesCommands =
+  #  ''
+  #    cat <<'EOF' > $out/99-other.rules
+  #    ${config.boot.initrd.services.udev.rules}
+  #    EOF
+  #  '';
 
   # Enable the OpenSSH daemon.
   services.openssh = {

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -8,6 +8,10 @@ let
     '';
     destination = "/etc/udev/rules.d/99-ham.rules";
   };
+
+  myAXTools = pkgs.ax25-tools.overrideAttrs (old: rec {
+    configureFlags = [ "--sysconfdir=/etc" "--localstatedir=/var/lib" ];
+  });
 in
 {
   imports =
@@ -54,7 +58,8 @@ in
       alsa-utils # Soundcard utils
       ardopc
       aprx
-      ax25-tools
+      #ax25-tools
+      myAXTools
       ax25-apps
       tncattach
       libax25

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -48,6 +48,7 @@
       ax25-apps
       tncattach
       libax25
+      hamlib_4
       pat
       flashtnc
       tmux


### PR DESCRIPTION
## Description

- flake.lock - ham-overlay master -> 2023-07-03
- init ardopc on mulligan
- init hamlib
- init alsa-utils
- init udev rule for ninotnc
- flake.lock - ham-overlay -> 2023-07-24
- set localstatedir for ax-tools
- enable AX.25 services in mulligan

## Tests

- Confirmed that `ardop` and `alsa` work with `pat` for HF winklink

- Able to correctly consume nixos modules from `ham-overlay` for `ax25d`, `axlistend`, `beacond`, and `mheardd`
