### PR TITLE
[READY] - bumping flake inputs for 08/2023

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1690222048,
-        "narHash": "sha256-iqMPXoe61HzCQeTU59pNthbLSQbrQH2QZvnUE8o0+fE=",
+        "lastModified": 1691697034,
+        "narHash": "sha256-OkkzScMy3bvwM3RjaFQasSCqeGEmnyuQr3msHJnMOhk=",
         "owner": "sarcasticadmin",
         "repo": "ham-overlay",
-        "rev": "c473b3524e3bfab9d53392c9a80075d16c9ed2bd",
+        "rev": "ae4f6598391185435313df7de32beb8810c50103",
         "type": "github"
       },
       "original": {
         "owner": "sarcasticadmin",
         "repo": "ham-overlay",
-        "rev": "c473b3524e3bfab9d53392c9a80075d16c9ed2bd",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688177999,
-        "narHash": "sha256-JZ5nk90Ym79b4J593xYb0mI79QxU0efJLuCU3sXDalQ=",
+        "lastModified": 1690271650,
+        "narHash": "sha256-qwdsW8DBY1qH+9luliIH7VzgwvL+ZGI3LZWC0LTiDMI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0de86059128947b2438995450f2c2ca08cc783d5",
+        "rev": "6dc93f0daec55ee2f441da385aaf143863e3d671",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     ham-overlay = {
-      url = "github:sarcasticadmin/ham-overlay/c473b3524e3bfab9d53392c9a80075d16c9ed2bd";
+      url = "github:sarcasticadmin/ham-overlay";
       # Make sure to set to the specific input of the remote flake
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -11,6 +11,7 @@ in
     binutils
     btop
     dig
+    dmidecode
     file
     wget
     git
@@ -25,10 +26,12 @@ in
     myVim # Custom vim
     nixpkgs-fmt
     openssl
+    pciutils
     parted
     shellcheck
     tree
     manix # useful search for nix docs
+    usbutils
     unzip
   ];
 

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -8,6 +8,7 @@ in
 {
   # install Nebulaworks packages
   environment.systemPackages = with pkgs; [
+    binutils
     btop
     dig
     file

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -9,9 +9,6 @@ let
     destination = "/etc/udev/rules.d/99-ham.rules";
   };
 
-  myAXTools = pkgs.ax25-tools.overrideAttrs (old: rec {
-    configureFlags = [ "--sysconfdir=/etc" "--localstatedir=/var/lib" ];
-  });
 in
 {
   imports =
@@ -58,8 +55,7 @@ in
       alsa-utils # Soundcard utils
       ardopc
       aprx
-      #ax25-tools
-      myAXTools
+      ax25-tools
       ax25-apps
       tncattach
       libax25
@@ -103,24 +99,20 @@ in
 
   services.ax25d = {
     enable = true;
-    package = myAXTools;
   };
 
   services.mheardd = {
     enable = true;
-    package = myAXTools;
   };
 
   #services.beacond = {
   #  enable = true;
-  #  package = myAXTools;
   #  interval = 5;
   #  message = "hello this is rob";
   #};
 
   services.axlistend = {
     enable = true;
-    package = myAXTools;
   };
 
   # Bug in kernels ~5.4<5.19


### PR DESCRIPTION
## Description

- init binutils for _common/base
- flake.lock: nixos 23.05 -> 2023-07-25
- remove ax25-tools pkg override for mulligan
- flake.lock - ham-overlay -> 2023-08-10
- init dmidecode, pciutils, and usbutils

## Tests

- Confirmed working on `mulligan` and `rufio`
