### PR TITLE
[READY] - bump nixpkgs and init beeper

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691592289,
-        "narHash": "sha256-Lqpw7lrXlLkYra33tp57ms8tZ0StWhbcl80vk4D90F8=",
+        "lastModified": 1696039360,
+        "narHash": "sha256-g7nIUV4uq1TOVeVIDEZLb005suTWCUjSY0zYOlSBsyE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9034b46dc4c7596a87ab837bb8a07ef2d887e8c7",
+        "rev": "32dcb45f66c0487e92db8303a798ebc548cadedc",
         "type": "github"
       },
       "original": {

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -105,7 +105,8 @@ in
       tailscale
       android-udev-rules
       vagrant
-      isync  #mbsync
+      beeper
+      isync #mbsync
       protonmail-bridge
       #aerc
       aercUnstable


### PR DESCRIPTION
## Description

- flake.lock - nixos 23.05 -> 2023-10-02
- driver: init beeper

## Tests

- Tested on `driver`
