### PR TITLE
[READY] - inputs attrset, pipewire, and alacritty

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,10 +36,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "ham-overlay": "ham-overlay",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     ham-overlay = {
       url = "github:sarcasticadmin/ham-overlay";
       # Make sure to set to the specific input of the remote flake
@@ -21,6 +22,7 @@
   outputs =
     { self
     , nixpkgs
+    , nixpkgs-unstable
     , ham-overlay
     }: {
       nixosConfigurations = {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     , nixpkgs
     , nixpkgs-unstable
     , ham-overlay
-    }: {
+    }@inputs: {
       nixosConfigurations = {
         cola = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
@@ -35,6 +35,7 @@
         };
         driver = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
+          specialArgs = { inherit inputs; };
           modules = [ ./nix/machines/driver/configuration.nix ];
         };
         mulligan = nixpkgs.lib.nixosSystem {

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -9,18 +9,18 @@ let
     nixExtensions = [
       (pkgs.fetchFirefoxAddon {
         name = "ublock"; # Has to be unique!
-        url = "https://addons.mozilla.org/firefox/downloads/file/4103048/ublock_origin-1.49.2.xpi"; # Get this from about:addons
-        sha256 = "sha256-OSZkhvcgzTHSkdL9rXhiWweXgqBVF+GTbux+eAvCqE0=";
+        url = "https://addons.mozilla.org/firefox/downloads/file/4171020/ublock_origin-1.52.2.xpi"; # Get this from about:addons
+        sha256 = "sha256-6O4/nVl6bULbnXP+h8HVId40B1X9i/3WnkFiPt/gltY=";
       })
       (pkgs.fetchFirefoxAddon {
         name = "bitwarden";
-        url = "https://addons.mozilla.org/firefox/downloads/file/4103016/bitwarden_password_manager-2023.4.0.xpi";
-        sha256 = "sha256-SE62pk027V7jx+XWLQk2fMOmR3/4DavRPh3B6Syoeyg=";
+        url = "https://addons.mozilla.org/firefox/downloads/file/4170561/bitwarden_password_manager-2023.9.1.xpi";
+        sha256 = "sha256-RtT+EOo6F1empMDXKPP3Zdk4g/dCo+u3PzauuA7sVak=";
       })
       (pkgs.fetchFirefoxAddon {
-        name = "zoomScheduler";
-        url = "https://addons.mozilla.org/firefox/downloads/file/4101383/zoom_new_scheduler-2.1.42.xpi";
-        sha256 = "sha256-xJBHh6ZyOPMkf1GOa7dC41WBi15x4qreeJxUydfglqQ=";
+        name = "zoomExtension";
+        url = "https://addons.mozilla.org/firefox/downloads/file/4158802/zoom_new_scheduler-2.1.47.xpi";
+        sha256 = "sha256-v8fDftZS8Pjq9oz2fiJNeZTQGyQepF4OJUQpNuI7n/0=";
       })
     ];
 

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -51,6 +51,7 @@ in
     gomuks # matrix
     zoom-us
     zathura # simple pdf viewer
+    alacritty
     obsidian
     shiori
     xsel

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -71,9 +71,12 @@ in
   # Enable CUPS to print documents.
   services.printing.enable = true;
   services.printing.drivers = [ pkgs.gutenprint ];
-  # Enable sound.
+  # Enable pipewire for sound.
   sound.enable = true;
-  hardware.pulseaudio.enable = true;
+  hardware.pulseaudio.enable = false;
+  services.pipewire.enable = true;
+  services.pipewire.alsa.enable = true;
+  services.pipewire.pulse.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.rherna = {
@@ -108,6 +111,8 @@ in
       android-udev-rules
       vagrant
       beeper
+      pavucontrol
+      pulsemixer
       isync #mbsync
       protonmail-bridge
       #aerc

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -27,6 +27,8 @@ in
     experimental-features = nix-command flakes
   '';
 
+  boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+
   # enabled apropos and "man -K" searching
   # https://nixos.org/manual/nixos/stable/options.html#opt-documentation.man.generateCaches
   documentation.man.generateCaches = true;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, ... }:
+{ config, pkgs, inputs, ... }:
 let
   aercUnstable = pkgs.callPackage ./aerc { };
 in


### PR DESCRIPTION
## Description

- flake.nix: init nixpkgs-unstable
- pass inputs as attrset
- emulate nix for arm64
- pipewire: init
- firefox plugins: bump bitwarden, ublock origin, zoomus
- _common/desktop: init alacritty
