### PR TITLE
[READY] - Fix chrome for 23.11 and add nmap pkg

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1705496572,
-        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -27,6 +27,7 @@ in
     gnumake
     jq
     lsof
+    inetutils # telnet,ftp,etc
     myVim # Custom vim
     nixpkgs-fmt
     openssl

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -85,6 +85,18 @@ in
     };
   };
 
+  programs.chromium = {
+    enable = true;
+    extraOpts = {
+      "DefaultInsecureContentSetting" = true;
+      "BrowserSignin" = 0;
+      "SyncDisabled" = true;
+      "PasswordManagerEnabled" = false;
+      "SpellcheckEnabled" = true;
+      "DnsOverHttpsMode" = "off";
+    };
+  };
+
   services.xserver = {
     enable = true;
 

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -33,6 +33,7 @@ in
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
 
   networking.hostName = "driver"; # Define your hostname.
   # Need to be set for ZFS or else leads to:

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -95,6 +95,7 @@ in
       gnupg
       pcsclite
       pinentry
+      nmap
       strace
       tailscale
       android-udev-rules


### PR DESCRIPTION
## Description

- common/base: include inettools for ftp, telnet, etc.
- base/desktop: set chromium to use sane policies
- driver: init nmap pkg
- bump nixpkgs-unstable

## Tests

- Tested on `driver`
