### PR TITLE
[READY] - wg for driver and nixpkgs unstable bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -12,6 +12,7 @@ in
     [
       ./hardware-configuration.nix
       ./home.nix
+      ./wg.nix
     ];
 
   # Necessary in most configurations
@@ -114,6 +115,7 @@ in
       msmtp
       tio
       xosd
+      wireguard-tools
     ];
 
     etc."wpa_supplicant.conf" = {

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -116,6 +116,7 @@ in
       tio
       xosd
       wireguard-tools
+      ntfs3g
     ];
 
     etc."wpa_supplicant.conf" = {

--- a/nix/machines/driver/wg.nix
+++ b/nix/machines/driver/wg.nix
@@ -1,0 +1,8 @@
+{
+  networking.wg-quick.interfaces = {
+    # the interface arbitrarily.
+    wg0 = {
+      configFile = "/persist/etc/wireguard/ec-rmsgw.conf";
+    };
+  };
+}


### PR DESCRIPTION
## Description

Setting up wg on driver for ec connectivity.

## Tests

- `driver` works as expected
