### PR TITLE
[READY] - ax25 kernel module and bump ham-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705723486,
-        "narHash": "sha256-8CP1bFiWdx/vJWXsmG5VXW2hKs5ymTeyQbUTHIANbKA=",
+        "lastModified": 1717966866,
+        "narHash": "sha256-N6N5CbUn+JEhOaDyZV/uhp7nQH/u7tnZAORMJ+SHAoE=",
         "owner": "sarcasticadmin",
         "repo": "ham-overlay",
-        "rev": "de66987661c534318d289e0b24bc57131a1ef0a4",
+        "rev": "cb43c8915d31a37e69be083be0ee7d3988aa673a",
         "type": "github"
       },
       "original": {

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -120,6 +120,11 @@ in
   # Resulting in pat to error with: address already in use error after first connection
   #boot.kernelPackages = pkgs.linuxPackages_6_0;
 
+  # Enable tlp for stricter governance of power management
+  # Validate status: `sudo tlp-stat -b`
+  services.tlp = {
+    enable = true;
+  };
 
   system.stateVersion = config.system.nixos.version;
 }

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -35,24 +35,19 @@ in
     experimental-features = nix-command flakes
   '';
 
-  #boot.kernelPatches = [{
-  #  name = "packet-radio-protocols";
-  #  patch = null;
-  #  extraConfig = ''
-  #    HAMRADIO y
-  #    AX25 y
-  #    AX25_DAMA_SLAVE y
-  #  '';
-  #}];
   boot.kernelPatches = lib.singleton {
     name = "ax25-ham";
     patch = null;
     extraStructuredConfig = with lib.kernel; {
-      HAMRADIO = yes;
-      AX25 = yes;
-      AX25_DAMA_SLAVE = yes;
+      HAMRADIO = lib.kernel.yes;
+      AX25 = lib.kernel.module;
     };
   };
+
+  # After setting the bool for HAMRADIO in the kernel we can set ax25 either in extraStructuredConfig
+  # or via boot.kernelModules to build it as an individual module instead of built in
+  # https://github.com/torvalds/linux/blob/d20f6b3d747c36889b7ce75ee369182af3decb6b/net/ax25/Kconfig#L8
+  #boot.kernelModules = [ "ax25" ];
 
   environment = {
     # Installs all necessary packages for the minimal

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -120,5 +120,6 @@ in
   # Resulting in pat to error with: address already in use error after first connection
   #boot.kernelPackages = pkgs.linuxPackages_6_0;
 
-  services.tlp.enable = true;
+
+  system.stateVersion = config.system.nixos.version;
 }


### PR DESCRIPTION
## Description

Investigated getting `ax25` to be installed as a kernel module. Turns out the `HAMRADIO` boolean must be set or else any other settings ignored for setting up the `ax25*` modules: https://github.com/torvalds/linux/blob/d20f6b3d747c36889b7ce75ee369182af3decb6b/net/ax25/Kconfig#L8

## Tests

- tested on `mulligan` and ninotnc using `pat`
