### PR TITLE
[READY] - nixpkgs-unstable bump and darwin pkg check for base

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719690277,
-        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
+        "lastModified": 1720418205,
+        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+        "rev": "655a58a72a6601292512670343087c2d75d859c1",
         "type": "github"
       },
       "original": {

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -1,5 +1,5 @@
 # The base toolchain that I expect on a system
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   # Need the pythons in my vims
@@ -7,14 +7,13 @@ let
 in
 {
   # install Nebulaworks packages
-  environment.systemPackages = with pkgs; [
+  environment.systemPackages = with pkgs; ([
     bc
     binutils
     bc
     btop
     cachix
     dig
-    dmidecode
     file
     wget
     git
@@ -34,13 +33,15 @@ in
     nixpkgs-fmt
     openssl
     pciutils
-    parted
     shellcheck
     tree
     manix # useful search for nix docs
-    usbutils
     unzip
-  ];
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    pkgs.dmidecode
+    pkgs.parted
+    pkgs.usbutils
+  ]);
 
   # Purge nano from being the default
   environment.variables = { EDITOR = "vim"; };


### PR DESCRIPTION
## Description

Bumping nixpkgs-unstable to get latest version of beeper. Marking pkgs in `base.nix` as optional to work with Darwin.

## Tests

- Tested on `driver`
