### PR TITLE
[READY] - Followup for base.nix

### DIFF
--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -7,7 +7,7 @@ let
 in
 {
   # install Nebulaworks packages
-  environment.systemPackages = with pkgs; ([
+  environment.systemPackages = with pkgs; [
     bc
     binutils
     bc
@@ -38,10 +38,10 @@ in
     manix # useful search for nix docs
     unzip
   ] ++ lib.optionals (!stdenv.isDarwin) [
-    pkgs.dmidecode
-    pkgs.parted
-    pkgs.usbutils
-  ]);
+    dmidecode
+    parted
+    usbutils
+  ];
 
   # Purge nano from being the default
   environment.variables = { EDITOR = "vim"; };

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -31,7 +31,6 @@ in
     neovim
     ripgrep # needed for nvim telescope
     nixpkgs-fmt
-    openssl
     pciutils
     shellcheck
     tree
@@ -41,6 +40,7 @@ in
     dmidecode
     parted
     usbutils
+    openssl # conflicts with nix-darwin
   ];
 
   # Purge nano from being the default


### PR DESCRIPTION
## Description

Fixing `openssl` conflict when consume `base.nix` via nix-darwin

## Tests

- working on macOS
