### PR TITLE
[READY] - driver/nixpkgs-review: always use from unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -109,7 +109,7 @@ in
       mosh
       imagemagick
       magic-wormhole
-      nixpkgs-review
+      pkgs-unstable.nixpkgs-review
       # hardware key
       gnupg
       pcsclite


### PR DESCRIPTION
## Description

ofborg eval was removed in nixpkgs-review 3.0.1 so leveraging unstable for this package going forward for compat.

## Tests

- Tested on `driver`
