### PR TITLE
misc: ham kernel, driver zram and pkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1736012469,
-        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
             ./nix/machines/_common/users.nix
             ./nix/machines/driver/configuration.nix ];
         };
-        mulligan = nixpkgs.lib.nixosSystem {
+        mulligan = nixpkgs-unstable.lib.nixosSystem {
           system = "x86_64-linux";
           modules = [
             ({ config, pkgs, ... }: { nixpkgs.overlays = [ ham-overlay.overlays.default ]; })

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -121,6 +121,7 @@ in
       android-udev-rules
       #vagrant  # broken as of 24.11
       pkgs-unstable.beeper
+      pkgs-unstable.signal-desktop-bin
       pkgs-unstable.prusa-slicer
       pavucontrol
       openscad

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -103,7 +103,7 @@ in
       freetube
       gh
       glab
-      ticker # stocks
+      pkgs-unstable.ticker # stocks
       newsboat
       icdiff
       mosh

--- a/nix/machines/driver/hardware-configuration.nix
+++ b/nix/machines/driver/hardware-configuration.nix
@@ -46,6 +46,10 @@
       fsType = "zfs";
     };
 
+  # Leverage compressed RAM based block devices named /dev/zram<id>
+  # ref: https://www.kernel.org/doc/Documentation/blockdev/zram.txt
+  zramSwap.enable = true;
+
   swapDevices = [ ];
 
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -41,7 +41,7 @@ in
     # Installs all necessary packages for the minimal
     systemPackages = with pkgs; [
       alsa-utils # Soundcard utils
-      ardopc
+      #ardopc
       aprx
       ax25-tools
       ax25-apps
@@ -55,7 +55,7 @@ in
       screen
       tio
       kermit
-      wwl
+      #wwl
     ];
 
     # libax25, etc. are set to assume the common config path

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -35,19 +35,7 @@ in
     experimental-features = nix-command flakes
   '';
 
-  boot.kernelPatches = lib.singleton {
-    name = "ax25-ham";
-    patch = null;
-    extraStructuredConfig = with lib.kernel; {
-      HAMRADIO = lib.kernel.yes;
-      AX25 = lib.kernel.module;
-    };
-  };
-
-  # After setting the bool for HAMRADIO in the kernel we can set ax25 either in extraStructuredConfig
-  # or via boot.kernelModules to build it as an individual module instead of built in
-  # https://github.com/torvalds/linux/blob/d20f6b3d747c36889b7ce75ee369182af3decb6b/net/ax25/Kconfig#L8
-  #boot.kernelModules = [ "ax25" ];
+  boot.kernelPackages = pkgs.linuxPackages_ham;
 
   environment = {
     # Installs all necessary packages for the minimal

--- a/nix/machines/mulligan/configuration.nix
+++ b/nix/machines/mulligan/configuration.nix
@@ -115,5 +115,6 @@ in
     enable = true;
   };
 
-  system.stateVersion = config.system.nixos.version;
+  #system.stateVersion = config.system.nixos.version;
+  system.stateVersion = "25.05";
 }


### PR DESCRIPTION
## Description

Enable upstream nix ham radio kernel from https://github.com/NixOS/nixpkgs/pull/389291

And misc changes for driver: zram, pkgs, etc.

## AC

- Tested against oddball for ham
- Tested against driver
