### PR TITLE
flake.inputs: nixos 24.11 -> 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,16 +42,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732981179,
-        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
+        "lastModified": 1747953325,
+        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
+        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     ham-overlay = {
       url = "github:sarcasticadmin/ham-overlay";

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -39,7 +39,7 @@ in
     xsel
     viewnior
     mpv
-    xournal # pdf annotations
+    xournalpp # pdf annotations
     xorg.xmodmap # util for modding keymaps and pointer button mappings in Xorg
     #imagemagick # dup might be a problem?
   ];
@@ -120,6 +120,9 @@ in
       defaultSession = "none+i3";
     };
   };
+
+  # required as of 25.05 since PAM services for i3lock now default to disabled
+  programs.i3lock.enable = true;
 
   environment.etc."i3status.conf" = {
     source = "${inputs.self.packages.${pkgs.system}.dotfiles}/workstation/.i3status.conf";

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -88,7 +88,6 @@ in
     enable = true;
     alsa.enable = true;
     pulse.enable = true;
-    systemWide = true;
   };
 
   users.groups.plugdev = { };

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -83,7 +83,7 @@ in
   services.printing.enable = true;
   services.printing.drivers = [ pkgs.gutenprint ];
 
-  hardware.pulseaudio.enable = false;
+  services.pulseaudio.enable = false;
   services.pipewire = {
     enable = true;
     alsa.enable = true;
@@ -310,5 +310,5 @@ in
     };
   };
 
-  system.stateVersion = config.system.nixos.version;
+  system.stateVersion = config.system.nixos.release;
 }


### PR DESCRIPTION
## Description

- **flake: bump nixpkgs 24.11 -> 25.05**
- **driver: updates to config for 25.05**
- **driver: remove pipewire.systemWide = true**

## Tests

- `driver` rebooted and working as expected on 25.05
