### PR TITLE
nix.{common,driver}: transition from wpa_supplicant to iwd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
             ./nix/machines/_common/desktop.nix
             ./nix/machines/_common/base.nix
             ./nix/machines/_common/users.nix
+            ./nix/machines/_common/wifi.nix
             ./nix/machines/driver/configuration.nix ];
         };
         mulligan = nixpkgs-unstable.lib.nixosSystem {

--- a/nix/machines/_common/desktop.nix
+++ b/nix/machines/_common/desktop.nix
@@ -127,4 +127,9 @@ in
   environment.etc."i3status.conf" = {
     source = "${inputs.self.packages.${pkgs.system}.dotfiles}/workstation/.i3status.conf";
   };
+
+  # good baseline of fonts
+  fonts = {
+    enableDefaultPackages = true;
+  };
 }

--- a/nix/machines/_common/wifi.nix
+++ b/nix/machines/_common/wifi.nix
@@ -1,13 +1,24 @@
+{ pkgs, ... }:
 {
-  # Enables wireless support via wpa_supplicant
-  networking.wireless.enable = true;
-  # Option is misleading but we dont want it
-  networking.wireless.userControlled.enable = false;
-  # Allow configuring networks "imperatively"
-  networking.wireless.allowAuxiliaryImperativeNetworks = true;
-
-  environment.etc."wpa_supplicant.conf" = {
-    source = "/persist/etc/wpa_supplicant.conf";
-    mode = "symlink";
+  networking.wireless.iwd = {
+    enable = true;
+    settings = {
+      Settings = {
+        AutoConnect = false;
+      };
+    };
   };
+
+  environment.systemPackages = with pkgs; [
+    impala
+  ];
+
+  fonts = {
+    packages = with pkgs; [
+      # impala needs symbols
+      # https://github.com/pythops/impala/issues/8
+      nerd-fonts.symbols-only
+    ];
+  };
+
 }

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -54,13 +54,6 @@ in
   # - ZFS requires networking.hostId to be set
   networking.hostId = "6f602d2b";
 
-  # Enables wireless support via wpa_supplicant
-  networking.wireless.enable = true;
-  # Option is misleading but we dont want it
-  networking.wireless.userControlled.enable = false;
-  # Allow configuring networks "imperatively"
-  networking.wireless.allowAuxiliaryImperativeNetworks = true;
-
   # Set your time zone.
   # time.timeZone = "Europe/Amsterdam";
 
@@ -74,7 +67,7 @@ in
   networking.dhcpcd.wait = "if-carrier-up";
   networking.interfaces.enp2s0f0.useDHCP = true;
   networking.interfaces.enp5s0.useDHCP = true;
-  networking.interfaces.wlp3s0.useDHCP = true;
+  networking.interfaces.wlan0.useDHCP = true;
 
   # Leave commented until tether is needed
   #networking.interfaces.enp7s0f4u2.useDHCP = true;
@@ -142,11 +135,6 @@ in
       chirp
       cc-tool # TI CC Debugger
     ];
-
-    etc."wpa_supplicant.conf" = {
-      source = "/persist/etc/wpa_supplicant.conf";
-      mode = "symlink";
-    };
   };
 
   users.users.rherna = {


### PR DESCRIPTION
## Description

- **nix.common.wifi: transition from wpa_supplicant to iwd**
- **nix.driver: used _common/wifi.nix**
- **nix.common.desktop: enable default fonts**

There still needs to be follow up to enable /persist to store wifi credentials

## Tested

- Tested on `driver`
