### PR TITLE
nix: bump nixpkgs-unstable and dotfiles

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs/dotfiles.nix
+++ b/nix/pkgs/dotfiles.nix
@@ -1,7 +1,7 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 let
   pname = "sarcasticadmin-dotfiles";
-  version = "2024.9.0";
+  version = "2025.9.0";
 in
 stdenvNoCC.mkDerivation {
   inherit pname version;
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation {
     owner = "sarcasticadmin";
     repo = "dotfiles";
     rev = "${version}";
-    hash = "sha256-V8yzDrRZE6vRMLTB/LnUQ8Rc/M3pysW6c98qkQNBdnk=";
+    hash = "sha256-6z2RDM4cjg1NnXyMz3oWkhKD41oMKOdlOdH8ldOlCGM=";
   };
 
   phases = "unpackPhase patchPhase installPhase";
@@ -18,6 +18,8 @@ stdenvNoCC.mkDerivation {
   prePatch = ''
     substituteInPlace i3/.i3/config \
           --replace '~/.i3/i3lock.sh' '${placeholder "out"}/i3/.i3/i3lock.sh'
+    substituteInPlace gnupg/.gnupg/gpg-agent.conf \
+          --replace 'pinentry-program /usr/bin/pinentry-tty' '/usr/bin/pinentry-tty /run/current-system/sw/bin/pinentry-tty'
     patchShebangs .
   '';
   installPhase = ''


### PR DESCRIPTION
## Description

Update dotfiles since they are a year out of date

Needed newer versions of some unstable packages so bumping

## Tests

- verified work on `driver`
