### PR TITLE
nixosConfigurations.driver: enable systemd.networkd and bump dotfiles

### DIFF
--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -48,29 +48,28 @@ in
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  networking.hostName = "driver"; # Define your hostname.
-  # Need to be set for ZFS or else leads to:
-  # Failed assertions:
-  # - ZFS requires networking.hostId to be set
-  networking.hostId = "6f602d2b";
+  networking = {
+    hostName = "driver"; # Define your hostname.
+    # Need to be set for ZFS or else leads to:
+    # Failed assertions:
+    # - ZFS requires networking.hostId to be set
+    hostId = "6f602d2b";
 
-  # Set your time zone.
-  # time.timeZone = "Europe/Amsterdam";
+    # The global useDHCP flag is deprecated, therefore explicitly set to false here.
+    # Per-interface useDHCP will be mandatory in the future, so this generated config
+    # replicates the default behaviour.
+    useDHCP = false;
 
-  # The global useDHCP flag is deprecated, therefore explicitly set to false here.
-  # Per-interface useDHCP will be mandatory in the future, so this generated config
-  # replicates the default behaviour.
-  networking.useDHCP = false;
+    # Make sure that dhcpcd doesnt timeout when interfaces are down
+    # ref: https://nixos.org/manual/nixos/stable/options.html#opt-networking.dhcpcd.wait
+    dhcpcd.wait = "if-carrier-up";
+    interfaces.enp2s0f0.useDHCP = true;
+    interfaces.enp5s0.useDHCP = true;
+    interfaces.wlan0.useDHCP = true;
 
-  # Make sure that dhcpcd doesnt timeout when interfaces are down
-  # ref: https://nixos.org/manual/nixos/stable/options.html#opt-networking.dhcpcd.wait
-  networking.dhcpcd.wait = "if-carrier-up";
-  networking.interfaces.enp2s0f0.useDHCP = true;
-  networking.interfaces.enp5s0.useDHCP = true;
-  networking.interfaces.wlan0.useDHCP = true;
-
-  # Leave commented until tether is needed
-  #networking.interfaces.enp7s0f4u2.useDHCP = true;
+    # Leave commented until tether is needed
+    #interfaces.enp7s0f4u2.useDHCP = true;
+  };
 
   # Enable CUPS to print documents.
   services.printing.enable = true;
@@ -247,12 +246,6 @@ in
   };
 
   # List services that you want to enable:
-
-  # Open ports in the firewall.
-  # networking.firewall.allowedTCPPorts = [ ... ];
-  # networking.firewall.allowedUDPPorts = [ ... ];
-  # Or disable the firewall altogether.
-  # networking.firewall.enable = false;
 
   # ZFS
   services.zfs = {

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -55,6 +55,9 @@ in
     # - ZFS requires networking.hostId to be set
     hostId = "6f602d2b";
 
+    # use systemd.networkd full stop
+    useNetworkd = true;
+
     # The global useDHCP flag is deprecated, therefore explicitly set to false here.
     # Per-interface useDHCP will be mandatory in the future, so this generated config
     # replicates the default behaviour.

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -74,6 +74,12 @@ in
     #interfaces.enp7s0f4u2.useDHCP = true;
   };
 
+  # The notion of "online" is a broken concept
+  # also cant guarantee that laptop will always have a connection
+  # https://github.com/systemd/systemd/blob/e1b45a756f71deac8c1aa9a008bd0dab47f64777/NEWS#L13
+  # https://github.com/NixOS/nixpkgs/issues/247608
+  systemd.network.wait-online.enable = false;
+
   # Enable CUPS to print documents.
   services.printing.enable = true;
   services.printing.drivers = [ pkgs.gutenprint ];

--- a/nix/pkgs/dotfiles.nix
+++ b/nix/pkgs/dotfiles.nix
@@ -1,7 +1,7 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 let
   pname = "sarcasticadmin-dotfiles";
-  version = "2025.9.0";
+  version = "2025.10.0";
 in
 stdenvNoCC.mkDerivation {
   inherit pname version;
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation {
     owner = "sarcasticadmin";
     repo = "dotfiles";
     rev = "${version}";
-    hash = "sha256-6z2RDM4cjg1NnXyMz3oWkhKD41oMKOdlOdH8ldOlCGM=";
+    hash = "sha256-mIIkUsqRyqV6jMcPzCGZ6Qpdm9kYPbEsHNQxdpvMLbE=";
   };
 
   phases = "unpackPhase patchPhase installPhase";


### PR DESCRIPTION
## Description

- i3 screenshots were broken, fixed upstream in dotfiles and bumped pkg https://github.com/sarcasticadmin/dotfiles/pull/123
- enable `systemd.networkd` for driver

## Tests

- confirmed working on `driver` 
