### PR TITLE
[READY] nixosConfigurations.driver: bump flake inputs to 25.11 and fix deprecations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764627417,
-        "narHash": "sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4=",
+        "lastModified": 1769524058,
+        "narHash": "sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5a88a6eceb8fd732b983e72b732f6f4b8269bef3",
+        "rev": "71a3fc97d80881e91710fe721f1158d3b96ae14d",
         "type": "github"
       },
       "original": {
@@ -42,27 +42,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764560356,
-        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "lastModified": 1769598131,
+        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764667669,
-        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     ham-overlay = {
       url = "github:sarcasticadmin/ham-overlay";

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -119,7 +119,7 @@ in
       # hardware key
       gnupg
       pcsclite
-      pinentry
+      pinentry-tty
       nmap
       mob
       strace

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -124,6 +124,7 @@ in
       mob
       strace
       tailscale
+      twingate
       android-udev-rules
       #vagrant  # broken as of 24.11
       pkgs-unstable.beeper
@@ -307,6 +308,8 @@ in
       STOP_CHARGE_THRESH_BAT0 = 80; # 80 and above it stops charging
     };
   };
+
+  services.twingate.enable = true;
 
   system.stateVersion = config.system.nixos.release;
 }

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -125,7 +125,6 @@ in
       strace
       tailscale
       twingate
-      android-udev-rules
       #vagrant  # broken as of 24.11
       pkgs-unstable.beeper
       pkgs-unstable.signal-desktop-bin
@@ -156,7 +155,6 @@ in
   };
 
   services.udev.packages = with pkgs; [
-    android-udev-rules
     cc-tool # TI CC Debugger
     direwolf
   ];

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -51,6 +51,9 @@ in
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Give me all network logs
+  systemd.services."systemd-networkd".environment.SYSTEMD_LOG_LEVEL = "debug";
+
   networking = {
     hostName = "driver"; # Define your hostname.
     # Need to be set for ZFS or else leads to:

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -307,7 +307,8 @@ in
     };
   };
 
-  services.twingate.enable = true;
+  # dont autostart the VPN
+  services.twingate.enable = false;
 
   system.stateVersion = config.system.nixos.release;
 }

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -69,9 +69,6 @@ in
     # replicates the default behaviour.
     useDHCP = false;
 
-    # Make sure that dhcpcd doesnt timeout when interfaces are down
-    # ref: https://nixos.org/manual/nixos/stable/options.html#opt-networking.dhcpcd.wait
-    dhcpcd.wait = "if-carrier-up";
     interfaces.enp2s0f0.useDHCP = true;
     interfaces.enp5s0.useDHCP = true;
     interfaces.wlan0.useDHCP = true;

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -142,7 +142,7 @@ in
       wireguard-tools
       ntfs3g
       chirp
-      cc-tool # TI CC Debugger
+      pkgs-unstable.cc-tool # TI CC Debugger
       inputs.self.packages.${pkgs.system}.cm108
       inputs.self.packages.${pkgs.system}.accrip
       inputs.self.packages.${pkgs.system}.myabcde
@@ -155,7 +155,7 @@ in
   };
 
   services.udev.packages = with pkgs; [
-    cc-tool # TI CC Debugger
+    pkgs-unstable.cc-tool # TI CC Debugger
     direwolf
   ];
   # Enable the OpenSSH daemon.

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -197,7 +197,7 @@ in
   # Remove warning from tailscale: Strict reverse path filtering breaks Tailscale exit node use and some subnet routing setups
   networking.firewall.checkReversePath = "loose";
 
-  services.logind.extraConfig = "HandleLidSwitch=ignore";
+  services.logind.settings.Login = { HandleLidSwitch = "ignore"; };
 
   # part of gnupg reqs
   services.pcscd.enable = true;

--- a/nix/machines/driver/nvim.nix
+++ b/nix/machines/driver/nvim.nix
@@ -52,21 +52,27 @@
             vibrantink2
             SpaceCamp
             {
+              # plugin needed to configure lsp with things like root file hints, etc.
               plugin = pkgs.vimPlugins.nvim-lspconfig;
               type = "lua";
               config = ''
                 lua << EOF
-local lspconfig = require'lspconfig'
-lspconfig.nixd.setup{}
-lspconfig.rust_analyzer.setup {
-  -- Server-specific settings. See `:help lspconfig-setup`
+vim.lsp.enable("nixd")
+                                                                                                                           -- rust-analyzer
+vim.lsp.config("rust_analyzer", {
   settings = {
-    ['rust-analyzer'] = {},
+    ["rust-analyzer"] = {},
   },
-}
-opts = {
-    inlay_hints = { enabled = true },
-},
+  inlay_hints = {
+    enabled = true,
+  },
+})
+
+vim.lsp.enable("rust_analyzer")
+
+-- enable inlay hints
+vim.lsp.inlay_hint.enable(true)
+
 --ensure that lsp doesnt mess with colorscheme
 --https://www.reddit.com/r/neovim/comments/zjqquc/comment/izwahv7/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
 vim.api.nvim_create_autocmd("LspAttach", {

--- a/nix/machines/rufio/configuration.nix
+++ b/nix/machines/rufio/configuration.nix
@@ -127,7 +127,7 @@ in
       # hardware key
       gnupg
       pcsclite
-      pinentry
+      pinentry-tty
       strace
       tailscale
       vagrant

--- a/nix/machines/rufio/configuration.nix
+++ b/nix/machines/rufio/configuration.nix
@@ -182,7 +182,7 @@ in
 
   networking.firewall.checkReversePath = "loose";
 
-  services.logind.extraConfig = "HandleLidSwitch=ignore";
+  services.logind.settings.Login = { HandleLidSwitch = "ignore"; };
 
   # part of gnupg reqs
   services.pcscd.enable = true;


### PR DESCRIPTION
## Description

Updates to 25.11 and fix deprecations

## Tests

- Tested on `driver`
