### PR TITLE
[READY] - nix.flake: bump nixpkgs input -> 20260204

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
         "type": "github"
       },
       "original": {

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -42,6 +42,7 @@ in
     parted
     usbutils
     openssl # conflicts with nix-darwin
+    units # gnu-units for unit everyday unit conversions
   ];
 
   # Purge nano from being the default


### PR DESCRIPTION
## Description

- **nix._common.base: enable GNU units**
- **flake.lock: Update**
