### PR TITLE
treewide: update all flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773506317,
-        "narHash": "sha256-qWKbLUJpavIpvOdX1fhHYm0WGerytFHRoh9lVck6Bh0=",
+        "lastModified": 1776613567,
+        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "878ec37d6a8f52c6c801d0e2a2ad554c75b9353c",
+        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773705440,
-        "narHash": "sha256-xB30bbAp0e7ogSEYyc126mAJMt4FRFh8wtm6ADE1xuM=",
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48652e9d5aea46e555b3df87354280d4f29cd3a3",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1773734432,
-        "narHash": "sha256-IF5ppUWh6gHGHYDbtVUyhwy/i7D261P7fWD1bPefOsw=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cda48547b432e8d3b18b4180ba07473762ec8558",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -36,6 +36,7 @@ in
     shellcheck
     tree
     manix # useful search for nix docs
+    zip
     unzip
   ] ++ lib.optionals (!stdenv.isDarwin) [
     dmidecode

--- a/nix/machines/driver/configuration.nix
+++ b/nix/machines/driver/configuration.nix
@@ -14,6 +14,9 @@ in
       ./nvim.nix
     ];
 
+  # need to be 6.18 to avoid https://copy.fail/
+  boot.kernelPackages = pkgs.linuxPackages_6_18;
+
   # Necessary in most configurations
   nixpkgs.config.allowUnfree = true;
 

--- a/nix/machines/router1/configuration.nix
+++ b/nix/machines/router1/configuration.nix
@@ -7,7 +7,8 @@
       ./disko.nix
     ];
 
-  #boot.supportedFilesystems = ["zfs"];
+  # need to be 6.18 to avoid https://copy.fail/
+  boot.kernelPackages = pkgs.linuxPackages_6_18;
 
   boot = {
     # For now copying from


### PR DESCRIPTION
## Description

Update daily systems to utilize latest 25.11 input and 6.18 kernel

## Tests

- Working on `driver` and `router1`
